### PR TITLE
Rotation and Grid Spacing Updates

### DIFF
--- a/mesafiles/SLURM_MISTgrid.sh
+++ b/mesafiles/SLURM_MISTgrid.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #SBATCH --job-name="<<RUNNAME>>"
-#SBATCH --partition=conroy,itc_cluster,shared
+#SBATCH --partition=conroy,itc_cluster,shared,sapphire
 #SBATCH --constraint="intel"
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=12

--- a/scripts/make_inlist_inputs.py
+++ b/scripts/make_inlist_inputs.py
@@ -44,10 +44,9 @@ def make_inlist_inputs(runname, startype, feh, afe, zbase, rot, net, gridtype="D
 
 # MIST2 - full
         bigmassgrid = np.unique(np.hstack((massgrid(0.1,0.65,0.05),massgrid(0.7,1.2,0.01),massgrid(1.25,2.0,0.05),\
-                                           massgrid(2.1,6.0,0.2),massgrid(6.5,9.0,0.5), \
+                                           massgrid(2.1,4.0,0.1),massgrid(4.2,6.2,0.2),massgrid(6.5,9.0,0.5), \
                                            massgrid(9,20,1),massgrid(25,35,5),massgrid(36,60,2), \
                                            massgrid(65,100,5),massgrid(100,300,10))))
-
         
 
     elif gridtype=="CUSTOM":

--- a/scripts/make_iso_input_file.py
+++ b/scripts/make_iso_input_file.py
@@ -88,7 +88,7 @@ def make_iso_input_file(runname, mode, basic, incomplete=[]):
             
     fmt_abun_info = "{:>10.4f}".format(Yval)+"{:>12.5e}".format(Zval)+"{:>7.2f}".format(fehval)+\
         "{:>12.2f}".format(afeval)+"{:>9}".format(vvcrit.split('vvcrit')[-1])+"\n"
-    header = ["#version string, max 8 characters\n", "2.2\n", "#initial Y, initial Z, [Fe/H], [alpha/Fe], v/vcrit\n",\
+    header = ["#version string, max 8 characters\n", "2.4\n", "#initial Y, initial Z, [Fe/H], [alpha/Fe], v/vcrit\n",\
         fmt_abun_info, "#data directories: 1) history files, 2) eeps, 3) isochrones\n", tracks_dir+"\n", eeps_dir+"\n", iso_dir+"\n", \
         "# read history_columns\n", os.path.join(os.environ['ISO_DIR'], mhc_file)+"\n", "# specify tracks\n", str(len(tracks_list))+"\n"]
     footer = ["#specify isochrones\n", iso_file, "min_max\n", "log10\n", "107\n", "5.0\n", "10.3\n", "single\n"]


### PR DESCRIPTION
Summary of changes:

1. Mass grid
Changes spacing from 0.2 Msun to 0.1 Msun in the 2-4 Msun range. This gives much better resolution to a key place for the WD IFMR.

2. Fuller TS for rotation
Instead of a sharp turnoff at 4 Msun, implements a smooth turnoff from 4 to 7 Msun. The scale factor is $\left(\frac{7-M}{7-4}\right)^2$, where a scale factor of 1 at $M=4$ means the full amount of AM transport from the Fuller model, and a scale factor of 0 at $M=7$ means Fuller TS AM transport is turned off. No changes to the MESA models for $M < 4$ or $M > 7$, but for $4<M<7$ there is still some amount of TSF angular momentum transport where there was almost none before, which helps the cores spin down. This produces much more reasonable white dwarf progenitors on the high mass end. Without this change, MIST 2.3 produced very rapidly rotating WDs for progenitors above 4 Msun, had a discontinuity in the IFMR at 4 Msun, and also produced some C/O WD cores in the 1.05-1.10 Msun mass range where they should ignite core C and become O/Ne WDs.

3. Suggests updating version number to 2.4.

4. Adds newer `sapphire` partition as another option for running MESA models, which is similar to `shared` but has even more capacity.